### PR TITLE
ENH: use midpoint rooting

### DIFF
--- a/ghosttree/scaffold/hybridtree.py
+++ b/ghosttree/scaffold/hybridtree.py
@@ -87,7 +87,7 @@ def scaffold_extensions_into_foundation(otu_file_fh, extension_taxonomy_fh,
                       " tmp/mini_tree_gt.nwk")
             mini_tree = read("tmp/mini_tree_gt.nwk", format='newick',
                              into=TreeNode)
-            node.extend(mini_tree.children[:])
+            node.extend(mini_tree.root_at_midpoint().children[:])
         except:
             continue
     os.system("rm -r tmp")


### PR DESCRIPTION
I was surprised to see that there weren't any test failures as a result. When I popped the hood on the unit testing code, I didn't see anything specific for assessing the topology of the resulting tree. It wasn't clear how best to add a test for this change.