### PR TITLE
improved documentation of which reference fasta files to use for which ghost-trees

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,14 +3,25 @@ ghost-tree
 
 |Build Status| |Coverage Status|
 
-**UPDATE** 05/26/15: Please see the "trees" folder to download pre-built 
-reference phylogenetic trees. 
-
 ghost-tree is a bioinformatics tool that combines sequence data from two
 genetic marker databases into one phylogenetic tree that can be used for
 diversity analyses. One database is used as a backbone or scaffold because it
 provides better phylogeny across all phyla, and the other database provides
 finer taxonomic resolution.
+
+For application to ITS, you don't need to install ghost-tree, but can use our pre-built trees. The ``trees`` directory contains pre-built reference phylogenetic trees for the `UNITE QIIME reference files available here <https://unite.ut.ee/repository.php>`_.
+
+The most recent ghost-trees we've created are for the `sh_qiime_release_s_30.12.2014 release of UNITE, available here <https://unite.ut.ee/sh_files/sh_qiime_release_s_30.12.2014.zip>`_. Depending on which of the fasta files you're using from that directory, you'd use the corresponding ghost-tree listed below:
+
+ * For ``sh_refs_qiime_ver6_97_30.12.2014.fasta``, use `ghosttree_UNITEv6_30.12.2014S_97_100clusters_052515.nwk <https://raw.githubusercontent.com/JTFouquier/ghost-tree/master/trees/ghost-trees_052515/ghosttree_UNITEv6_30.12.2014S_97_100clusters_052515.nwk>`_
+ *  For ``sh_refs_qiime_ver6_97_30.12.2014.fasta``, use  `ghosttree_UNITEv6_30.12.2014S_97_80clusters_052515.nwk <https://github.com/JTFouquier/ghost-tree/raw/master/trees/ghost-trees_052515/ghosttree_UNITEv6_30.12.2014S_97_80clusters_052515.nwk>`_
+ * For ``sh_refs_qiime_ver6_99_30.12.2014.fasta``, use `ghosttree_UNITEv6_30.12.2014S_99_100clusters_052515.nwk <https://raw.githubusercontent.com/JTFouquier/ghost-tree/master/trees/ghost-trees_052515/ghosttree_UNITEv6_30.12.2014S_99_100clusters_052515.nwk>`_
+ *  For ``sh_refs_qiime_ver6_99_30.12.2014.fasta``, use  `ghosttree_UNITEv6_30.12.2014S_99_80clusters_052515.nwk <https://github.com/JTFouquier/ghost-tree/raw/master/trees/ghost-trees_052515/ghosttree_UNITEv6_30.12.2014S_99_80clusters_052515.nwk>`_
+ * For ``sh_refs_qiime_ver6_dynamic_30.12.2014.fasta``, use `ghosttree_UNITEv6_30.12.2014S_dynamic_100clusters_052515.nwk <https://raw.githubusercontent.com/JTFouquier/ghost-tree/master/trees/ghost-trees_052515/ghosttree_UNITEv6_30.12.2014S_dynamic_100clusters_052515.nwk>`_
+ *  For ``sh_refs_qiime_ver6_dynamic_30.12.2014.fasta``, use  `ghosttree_UNITEv6_30.12.2014S_dynamic_80clusters_052515.nwk <https://github.com/JTFouquier/ghost-tree/raw/master/trees/ghost-trees_052515/ghosttree_UNITEv6_30.12.2014S_dynamic_80clusters_052515.nwk>`_
+
+
+
 
 ghost-tree requires two external software tools to build a hybrid-tree or
 the "ghost-tree":


### PR DESCRIPTION
@JTFouquier, I'm working on this with @johnchase and @kschwarzberg. We still have a couple of questions about this.

- [ ] Can you confirm that the notes that we added are correct? 
- [ ] When counting the tips in the different ghost-trees, we notice that there are more tips in your 80% re-clustered tree than in your 100% re-clustered tree:

    ```python
    In [8]: tree97_80 = TreeNode.read("ghosttree_UNITEv6_30.12.2014S_97_80clusters_052515.nwk")

    In [9]: tree97_100 = TreeNode.read("ghosttree_UNITEv6_30.12.2014S_97_100clusters_052515.nwk")

    In [10]: tree97_80
    Out[10]: <TreeNode, name: unnamed, internal node count: 29497, tips count: 29414>

    In [11]: tree97_100
    Out[11]: <TreeNode, name: unnamed, internal node count: 21204, tips count: 21020>
    ```

    Are we interpreting that correctly, and if so, is there a problem with these files? (There should be more 100% OTUs than 80% OTUs.)

- [ ] Since there are many more reference sequences than tips in the ghost-tree, we probably need to filter the reference sequences before we pick OTUs against them. Do you agree with that? Did you do that for the analyses in the paper? 