### PR TITLE
CI: use flake8 default include/exclude patterns; include all scripts explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ install:
   - pip install .
 script:
   - nosetests ghosttree --with-coverage
-  - flake8 ghosttree setup.py scripts
+  - flake8 ghosttree setup.py scripts/*
 after_success:
   - coveralls

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,2 @@
 [flake8]
-filename = *
-exclude = *.pyc, __pycache__
 max-line-length = 120


### PR DESCRIPTION
Remove `filename` and `exclude` settings from setup.cfg as flake8 was linting
non-Python files. Run flake8 explicitly over all scripts instead of searching
the scripts directory.

Resolves issue described in #34.