### PR TITLE
add parentheses to print

### DIFF
--- a/ghosttree/scaffold/hybridtree.py
+++ b/ghosttree/scaffold/hybridtree.py
@@ -81,15 +81,13 @@ def extensions_onto_foundation(otu_file_fh, extension_taxonomy_fh,
                                stderr=subprocess.PIPE)
     std_output, std_error = process.communicate()
     if re.search("command not found", std_error):
-        print("muscle, multiple sequence aligner, is not found. Is it" \
-              " installed? Is it in your path?")
+        print("muscle, multiple sequence aligner, is not found. Is it installed? Is it in your path?")
     std_output, std_error = "", ""
     process = subprocess.Popen("fasttree", shell=True, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
     std_output, std_error = process.communicate()
     if re.search("command not found", std_error):
-        print("fasttree, phylogenetic tree builder, is not found. Is it" \
-              " installed? Is it in your path?")
+        print("fasttree, phylogenetic tree builder, is not found. Is it installed? Is it in your path?")
     os.mkdir("tmp")
     os.mkdir(ghost_tree_fp)
     extension_genus_accession_list_dic = \

--- a/ghosttree/scaffold/hybridtree.py
+++ b/ghosttree/scaffold/hybridtree.py
@@ -81,15 +81,15 @@ def extensions_onto_foundation(otu_file_fh, extension_taxonomy_fh,
                                stderr=subprocess.PIPE)
     std_output, std_error = process.communicate()
     if re.search("command not found", std_error):
-        print "muscle, multiple sequence aligner, is not found. Is it" \
-              " installed? Is it in your path?"
+        print("muscle, multiple sequence aligner, is not found. Is it" \
+              " installed? Is it in your path?")
     std_output, std_error = "", ""
     process = subprocess.Popen("fasttree", shell=True, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
     std_output, std_error = process.communicate()
     if re.search("command not found", std_error):
-        print "fasttree, phylogenetic tree builder, is not found. Is it" \
-              " installed? Is it in your path?"
+        print("fasttree, phylogenetic tree builder, is not found. Is it" \
+              " installed? Is it in your path?")
     os.mkdir("tmp")
     os.mkdir(ghost_tree_fp)
     extension_genus_accession_list_dic = \

--- a/scripts/ghost-tree
+++ b/scripts/ghost-tree
@@ -239,7 +239,7 @@ def hybrid_tree(stderr, foundation_alignment, foundation_tree, exclude_id_list,
         c) log error file (this is an optional file that you can have if you
            type '--stderr')
     """
-    print "\n\nghost-tree is running now...\n\n"
+    print("\n\nghost-tree is running now...\n\n")
     _, std_error = extensions_onto_foundation(extension_trees_otu_map, extension_trees_taxonomy_file,
                                               extension_trees_sequence_file, foundation_alignment_file,
                                               ghost_tree_output_folder)
@@ -261,7 +261,7 @@ def hybrid_tree(stderr, foundation_alignment, foundation_tree, exclude_id_list,
 
     if exclude_id_list:
         os.unlink(ghost_tree_output_folder + "/ghost_tree_extension_accession_ids.txt")
-    print "\n...ghost-tree is complete.\n\n"
+    print("\n...ghost-tree is complete.\n\n")
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
I tried to install ghost-tree on Ubuntu and received an error SyntaxError: Missing parentheses in call to 'print'.
As I understand, in Python 3 print function should be invoked using parentheses. While in Python 2 there is no difference (with or without parentheses). So may be it's better to add them.

PS. I'm sorry for the first erroneous pull request - forgot to remove a backslash.